### PR TITLE
Fix installation on Windows

### DIFF
--- a/cargo-crev/README.md
+++ b/cargo-crev/README.md
@@ -38,7 +38,9 @@ See it in action:
 Join [crev gitter channel](https://gitter.im/dpc/crev), get help,
 report problems and feedback. Thank you!
 
-### Dependencies
+### Installation
+
+#### Unix
 
 `cargo-crev` has a couple of non-Rust dependencies:
 
@@ -49,6 +51,23 @@ sudo apt-get install openssl libssl-dev
 # argonautica build system
 sudo apt-get install clang llvm-dev libclang-dev
 ```
+
+Soon you should be able to to just `cargo install cargo-crev`, but until then,
+you need to install `cargo-crev` directly from github directory.
+
+```
+git clone https://github.com/dpc/crev
+cd crev
+cargo install -f --path cargo-crev
+```
+
+Afterwards you can use `cargo crev` command.
+
+#### Windows
+
+`cargo-crev` has a couple op non-Rust dependencies. Make sure you have
+[LLVM](http://releases.llvm.org/download.html) installed and added to your
+path.
 
 Soon you should be able to to just `cargo install cargo-crev`, but until then,
 you need to install `cargo-crev` directly from github directory.

--- a/recursive-digest/tests/sanity.rs
+++ b/recursive-digest/tests/sanity.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use crev_recursive_digest::DigestError;
 use digest::Digest;
 use std::collections::HashSet;
@@ -65,6 +66,16 @@ fn sanity() -> Result<(), DigestError> {
     Ok(())
 }
 
+#[cfg(target_family = "windows")]
+pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_file(src, dst)
+}
+
+#[cfg(target_family = "unix")]
+pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(src, dst)
+}
+
 /// Captured by:
 ///
 /// ```
@@ -86,7 +97,7 @@ fn backward_comp() -> Result<(), DigestError> {
     let path = path.join("g");
     fs::create_dir_all(&path)?;
 
-    std::os::unix::fs::symlink(std::path::PathBuf::from("../../a"), path.join("h"))?;
+    symlink_file(std::path::PathBuf::from("../../a"), path.join("h"))?;
 
     let dir_digest = crev_recursive_digest::get_recursive_digest_for_dir::<blake2::Blake2b, _>(
         &dir_path,


### PR DESCRIPTION
This solves the installation on Windows and closes #81. It adds installation instructions and uses conditional compilation for the latest `::unix::` usage.