### PR TITLE
#8: Better error messages when locked id password is wrong

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -320,7 +320,11 @@ fn review_crate(
     std::fs::remove_dir_all(&reviewed_pkg_dir)?;
 
     let passphrase = crev_common::read_passphrase()?;
-    let id = local.read_current_unlocked_id(&passphrase)?;
+
+    let id = local.read_current_unlocked_id(&passphrase).unwrap_or_else(|e| {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    });
 
     let review = proof::review::PackageBuilder::default()
         .from(id.id.to_owned())

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -439,7 +439,10 @@ impl Local {
             }
         }
 
-        let own_id = self.read_current_unlocked_id(&passphrase)?;
+        let own_id = self.read_current_unlocked_id(&passphrase).unwrap_or_else(|e| {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        });
 
         let trust = own_id.create_trust_proof(
             pub_ids,

--- a/crev-lib/src/repo/mod.rs
+++ b/crev-lib/src/repo/mod.rs
@@ -235,7 +235,10 @@ impl Repo {
 
         let ignore_list = HashSet::new();
         let _digest = crate::get_recursive_digest_for_git_dir(&self.root_dir, &ignore_list)?;
-        let id = local.read_current_unlocked_id(&passphrase)?;
+        let id = local.read_current_unlocked_id(&passphrase).unwrap_or_else(|e| {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        });
 
         let review = proof::review::PackageBuilder::default()
             .from(id.id.to_owned())
@@ -259,7 +262,10 @@ impl Repo {
         let _revision = self.read_revision()?;
         self.staging()?.enforce_current()?;
         let files = self.staging()?.to_review_files();
-        let id = local.read_current_unlocked_id(&passphrase)?;
+        let id = local.read_current_unlocked_id(&passphrase).unwrap_or_else(|e| {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        });
 
         let review = proof::review::CodeBuilder::default()
             .from(id.id.to_owned())


### PR DESCRIPTION
Is this a reasonable way to do error handling? Should handle both incorrect password and min password length error messages.