### PR TITLE
Use clippy on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ rust:
   - nightly
 
 script:
-  - if [ "$TRAVIS_RUST_VERSION" == "stable" ] ; then rustup component add rustfmt && cargo fmt --all -- --check; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "stable" ] ; then
+      rustup component add rustfmt clippy && cargo fmt --all -- --check && cargo clippy;
+    fi
   - cargo build --verbose
   - cargo test --verbose


### PR DESCRIPTION
closes #177 

I added clippy.

Off-Topic: I noticed travis has no caches so it takes time to complete. Should we set cache?

Checklist:

* [ ] `cargo +nightly fmt --all`
* [ ] Modify `CHANGELOG.md` if applicable
