### PR TITLE
Enforce clippy on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ rust:
 
 script:
   - if [ "$TRAVIS_RUST_VERSION" == "stable" ] ; then
-      rustup component add rustfmt clippy && cargo fmt --all -- --check && cargo clippy;
+      rustup component add rustfmt clippy &&
+      cargo fmt --all -- --check &&
+      cargo clippy --all-targets -- --deny clippy::all ||
+      exit 1;
     fi
   - cargo build --verbose
   - cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ you keep up with ever-changing ecosystem?
 
 ## Vision
 
-We would like Crev to become a general, language and ecosystem agnostic 
+We would like Crev to become a general, language and ecosystem agnostic
 system for establishing trust in Open Source code. We would like to have
 frontends integrated with all major Open Source package managers and ecosystems.
 
@@ -108,11 +108,11 @@ This allows answering queries like:
 
 * Not many people can review all their dependencies, but if every user
   at least skimmed through a couple of them, and shared that information with
-  others, we would be in much better situation.
-* Trust is fundamentally about people and community, not automatic-scans,
+  others, we would be in a much better situation.
+* Trust is fundamentally about people and community, not automatic scans,
   arbitrary metrics, process or bureaucracy. People have to judge both: code
   (code coverage, testing, quality, etc.) and trustworthiness of other
-  people (whos reviews do you trust, and how much).
+  people (whose reviews do you trust, and how much).
 * Code review tool should be language and ecosystem agnostic. Code is code, and should be reviewed.
 * Trust should be spread between many people, so one compromised or malicious
   actor can't abuse the system.

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -11,9 +11,8 @@ use crev_lib::{self, local::Local, ProofStore};
 use insideout::InsideOutIter;
 use resiter::FlatMap;
 use serde::Deserialize;
-use std::collections::BTreeMap;
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     default::Default,
     env,
     io::BufRead,
@@ -936,7 +935,7 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                     eprintln!();
                 }
 
-                for ((name, version), _digest) in &unclean_digests {
+                for (name, version) in unclean_digests.keys() {
                     term.eprint(
                         format_args!("Unclean crate {} {}\n", name, version),
                         ::term::color::RED,

--- a/recursive-digest/tests/sanity.rs
+++ b/recursive-digest/tests/sanity.rs
@@ -167,7 +167,7 @@ fn test_exclude_include_path() -> Result<(), DigestError> {
         let file_sum = hasher.result().to_vec();
 
         let mut hasher = blake2::Blake2b::new();
-        hasher.input("bar".as_bytes());
+        hasher.input(b"bar");
         let dir_sum = hasher.result().to_vec();
 
         let mut hasher = blake2::Blake2b::new();


### PR DESCRIPTION
Makes a Travis build actually fail if rustfmt or clippy aren't happy, and fixes two clippy lints and a few typos.

Checklist:

* [x] `cargo +nightly fmt --all`
* [ ] ~Modify `CHANGELOG.md` if applicable~
