### PR TITLE
Ignore symlink test on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build_script:
 - cmd: cargo build %RELEASE% --verbose --features="all %EXTRA_FEATURES%"
 
 test_script:
-- cmd: cargo test --all %RELEASE% --verbose --features="all %EXTRA_FEATURES%"
+- cmd: cargo test --all %RELEASE% --verbose --features="all %EXTRA_FEATURES%" -- --ignored
 
 for:
 

--- a/recursive-digest/tests/sanity.rs
+++ b/recursive-digest/tests/sanity.rs
@@ -88,7 +88,11 @@ pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> std::io::
 /// ln -sf /tmp/a/b/c/d/e/f/g/h "../../a"
 /// rblake2sum /tmp/a
 /// ```
+/// 
+/// Ignored by default on Windows, as users typically cannot create symlinks
+/// without running as admin.
 #[test]
+#[cfg_attr(target_family = "windows", ignore)]
 fn backward_comp() -> Result<(), DigestError> {
     let tmp_dir = TempDir::new("recursive-digest-test2")?;
 


### PR DESCRIPTION
Tests fail if a user is not able to create symlinks, which is true most
of the time on Windows.