### PR TITLE
Fix cargo crev verify's after_help not showing

### DIFF
--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+
+* Fixed detailed help for `verify` not showing.
+
 ## [0.8.0](https://github.com/dpc/crev/compare/cargo-crev-v0.7.0...cargo-crev-v0.8.0) - 2019-07-11
 ### Changed
 

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -118,24 +118,6 @@ impl From<VerificationRequirements> for crev_lib::VerificationRequirements {
 }
 
 #[derive(Debug, StructOpt, Clone)]
-/// Verify dependencies
-#[structopt(
-    name = "deps",
-    after_help = r"This will show the following information:
-
-- trust      - Trust check result: `pass` for trusted, `none` for lacking reviews, `flagged` or `dangerous` for crates with problem reports.
-- reviews    - Number of reviews for the specific version and for all available versions (total)
-- downloads  - Download counts from crates.io for the specific version and all versions
-- own.       - Owner counts from crates.io (known/all)
-- issues     - Number of issues repored (from trusted sources/all)
-- lines      - Lines of Rust code
-- geiger     - Geiger score: number of `unsafe` lines
-- flgs       - Flags for specific types of packages
-  - CB         - Custom Build
-- name       - Crate name
-- version    - Crate version
-- latest_t   - Latest trusted version"
-)]
 pub struct Verify {
     #[structopt(long = "verbose", short = "v")]
     /// Display more informations about the crates
@@ -456,7 +438,23 @@ pub enum Command {
     Edit(Edit),
 
     /// Verify dependencies
-    #[structopt(name = "verify")]
+    #[structopt(
+        name = "verify",
+        after_help = r"This will show the following information:
+
+- trust      - Trust check result: `pass` for trusted, `none` for lacking reviews, `flagged` or `dangerous` for crates with problem reports.
+- reviews    - Number of reviews for the specific version and for all available versions (total)
+- downloads  - Download counts from crates.io for the specific version and all versions
+- own.       - Owner counts from crates.io (known/all)
+- issues     - Number of issues repored (from trusted sources/all)
+- lines      - Lines of Rust code
+- geiger     - Geiger score: number of `unsafe` lines
+- flgs       - Flags for specific types of packages
+  - CB         - Custom Build
+- name       - Crate name
+- version    - Crate version
+- latest_t   - Latest trusted version"
+    )]
     Verify(Verify),
 
     /// Review a crate


### PR DESCRIPTION
Seems that the help text has to be attached within the subcommand enum
to show up