### PR TITLE
Fewer subcommands

### DIFF
--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -8,13 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fixed detailed help for `verify` not showing.
+* Renamed `cargo crev * id` to `cargo crev id *`, e.g. `cargo crev id new`, `cargo crev id export`. Added `cargo crev id show`.
+* Combined `advise`, `flag`, `report` into `review --advisory` and `review --issue`
 
 ## [0.8.0](https://github.com/dpc/crev/compare/cargo-crev-v0.7.0...cargo-crev-v0.8.0) - 2019-07-11
 ### Changed
 
 * `verify deps` was renamed to just `verify`
 * Not saving the default draft is considered as canceling the operation.
-* Revamp *advisories* system and add 
+* Revamp *advisories* system and add
 
 ### Added
 
@@ -29,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Advisories (https://github.com/dpc/crev/wiki/Advisories)
     * `cargo crev advise [name [version]]`
-    * `cargo crev query advisory [name [version]]` 
+    * `cargo crev query advisory [name [version]]`
 
 ## [0.6.0](https://github.com/dpc/crev/compare/cargo-crev-v0.5.0...cargo-crev-v0.6.0) - 2019-04-13
 ### Changed

--- a/cargo-crev/src/doc/getting_started.md
+++ b/cargo-crev/src/doc/getting_started.md
@@ -183,7 +183,7 @@ later if you wish.
 
 ```text
 $ cargo crev trust FYlr8YoYGVvDwHQxqEIs89reKKDy-oWisoO0qXXEfHE
-Error: User config not-initialized. Use `crev new id` to generate CrevID.
+Error: User config not-initialized. Use `crev id new` to generate CrevID.
 ```
 
 Oops. That's right. You can't sign an *proof* until you have your own identity.
@@ -197,10 +197,10 @@ else your typically host your code. Customarily the repository should be called 
 Note: `cargo-crev` requires the master branch to already exist, so the repository you have created
 has to contains at least one existing commit.
 
-Then run `cargo crev new id` like this:
+Then run `cargo crev id new` like this:
 
 ```text
-$ cargo crev new id --url https://github.com/YOUR-USERNAME/crev-proofs
+$ cargo crev id new --url https://github.com/YOUR-USERNAME/crev-proofs
 https://github.com/YOUR-USERNAME/crev-proofs cloned to /home/YOUR-USERNAME/.config/crev/proofs/Sp87YXeDKUyh4jImm23bCp1Gr-6eNkMoQogWbftNobQ
 CrevID will be protected by a passphrase.
 There's no way to recover your CrevID if you forget your passphrase.

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -437,7 +437,7 @@ pub enum Command {
     Verify(Verify),
 
     /// Review a crate (code review, security advisory, flag issues)
-    #[structopt(name = "review", alias = "report", alias = "flag", alias = "advise")]
+    #[structopt(name = "review")]
     Review(Review),
 
     /// Query Ids, packages, reviews...

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -351,9 +351,19 @@ pub struct Review {
     #[structopt(flatten)]
     pub common_proof_create: CommonProofCreate,
 
+    /// Create advisory urging to upgrade to a safe version
     #[structopt(long = "advisory")]
     pub advisory: bool,
 
+    /// This release contains advisory (important fix)
+    #[structopt(long = "affected")]
+    pub affected: Option<crev_data::proof::review::package::VersionRange>,
+
+    /// Severity of bug/security issue [none low medium high]
+    #[structopt(long = "severity")]
+    pub severity: Option<Level>,
+
+    /// Flag the crate as buggy/low-quality/dangerous
     #[structopt(long = "issue")]
     pub issue: bool,
 
@@ -365,44 +375,11 @@ pub struct Review {
     pub diff: Option<Option<semver::Version>>,
 }
 
-#[derive(Debug, StructOpt, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct AdviseCommon {
     /// This release contains advisory (important fix)
-    #[structopt(long = "affected", default_value = "major")]
     pub affected: crev_data::proof::review::package::VersionRange,
-
-    #[structopt(long = "severity", default_value = "medium")]
     pub severity: Level,
-}
-
-#[derive(Debug, StructOpt, Clone)]
-pub struct Advise {
-    #[structopt(flatten)]
-    pub common: ReviewOrGotoCommon,
-
-    #[structopt(flatten)]
-    pub common_proof_create: CommonProofCreate,
-
-    #[structopt(flatten)]
-    pub advise_common: AdviseCommon,
-}
-
-#[derive(Debug, StructOpt, Clone, Default)]
-pub struct ReportCommon {
-    #[structopt(long = "severity", default_value = "medium")]
-    pub severity: Level,
-}
-
-#[derive(Debug, StructOpt, Clone)]
-pub struct Report {
-    #[structopt(flatten)]
-    pub common: ReviewOrGotoCommon,
-
-    #[structopt(flatten)]
-    pub common_proof_create: CommonProofCreate,
-
-    #[structopt(flatten)]
-    pub report_common: ReportCommon,
 }
 
 #[derive(Debug, StructOpt, Clone)]
@@ -459,21 +436,9 @@ pub enum Command {
     )]
     Verify(Verify),
 
-    /// Review a crate
-    #[structopt(name = "review")]
+    /// Review a crate (code review, security advisory, flag issues)
+    #[structopt(name = "review", alias = "report", alias = "flag", alias = "advise")]
     Review(Review),
-
-    /// Flag a crate as buggy/low-quality/dangerous
-    #[structopt(name = "flag")]
-    Flag(Review),
-
-    /// Report that the crate is affected by a certain issue
-    #[structopt(name = "report")]
-    Report(Report),
-
-    /// Create advisory urging to upgrade to given package version
-    #[structopt(name = "advise")]
-    Advise(Advise),
 
     /// Query Ids, packages, reviews...
     #[structopt(name = "query")]

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -235,7 +235,7 @@ pub struct QueryDir {
 #[derive(Debug, StructOpt, Clone)]
 pub enum Query {
     /// Query Ids
-    #[structopt(name = "id")]
+    #[structopt(name = "id", alias = "new")]  // alias is a hack for back-compat
     Id(QueryId),
 
     /// Query reviews
@@ -256,10 +256,26 @@ pub enum Query {
 }
 
 #[derive(Debug, StructOpt, Clone)]
-pub enum Switch {
+pub enum Id {
+    /// Create a new Id
+    #[structopt(name = "new", alias = "id")] // alias is a hack for back-compat
+    New(NewId),
+
+    /// Export your own Id
+    #[structopt(name = "export")]
+    Export(ExportId),
+
+    /// Import an Id as your own
+    #[structopt(name = "import")]
+    Import,
+
+    /// Show your own Id
+    #[structopt(name = "show")]
+    Show,
+
     /// Change current Id
-    #[structopt(name = "id")]
-    Id(SwitchId),
+    #[structopt(name = "switch")]
+    Switch(SwitchId),
 }
 
 #[derive(Debug, StructOpt, Clone)]
@@ -395,17 +411,7 @@ pub struct ExportId {
 }
 
 #[derive(Debug, StructOpt, Clone)]
-pub enum Export {
-    #[structopt(name = "id")]
-    Id(ExportId),
-}
-
-#[derive(Debug, StructOpt, Clone)]
 pub enum Import {
-    /// Import an Id
-    #[structopt(name = "id")]
-    Id,
-
     /// Import proofs: resign proofs using current id
     ///
     /// Useful for mass-import of proofs signed by another ID
@@ -425,13 +431,9 @@ pub struct ImportProof {
 
 #[derive(Debug, StructOpt, Clone)]
 pub enum Command {
-    /// Create an Id, ...
-    #[structopt(name = "new")]
-    New(New),
-
-    /// Switch current Id, ...
-    #[structopt(name = "switch")]
-    Switch(Switch),
+    /// Manage your own Id (create new, show, export, import, switch)
+    #[structopt(name = "id", alias="new")]
+    Id(Id),
 
     /// Edit README.md of the current Id, ...
     #[structopt(name = "edit")]
@@ -519,11 +521,7 @@ pub enum Command {
     #[structopt(name = "clean")]
     Clean(ReviewOrGotoCommon),
 
-    /// Export an id, ...
-    #[structopt(name = "export")]
-    Export(Export),
-
-    /// Import an Id, ...
+    /// Import proofs, ...
     #[structopt(name = "import")]
     Import(Import),
 

--- a/cargo-crev/src/review.rs
+++ b/cargo-crev/src/review.rs
@@ -20,7 +20,7 @@ pub fn create_review_proof(
     name: &str,
     version: Option<&Version>,
     unrelated: UnrelatedOrDependency,
-    report_common: Option<opts::ReportCommon>,
+    report_severity: Option<crev_data::Level>,
     advise_common: Option<opts::AdviseCommon>,
     trust: TrustOrDistrust,
     proof_create_opt: &opts::CommonProofCreate,
@@ -87,7 +87,7 @@ pub fn create_review_proof(
             revision: vcs_info_to_revision_string(vcs),
             revision_type: proof::default_revision_type(),
         })
-        .review(if advise_common.is_some() || report_common.is_some() {
+        .review(if advise_common.is_some() || report_severity.is_some() {
             crev_data::Review::new_none()
         } else {
             trust.to_review()
@@ -120,10 +120,10 @@ pub fn create_review_proof(
         advisory.severity = advise_common.severity;
         review.advisories.push(advisory);
     }
-    if let Some(report_common) = report_common {
+    if let Some(severity) = report_severity {
         let mut report =
-            proof::review::package::Issue::new_with_severity("".into(), report_common.severity);
-        report.severity = report_common.severity;
+            proof::review::package::Issue::new_with_severity("".into(), severity);
+        report.severity = severity;
         review.issues.push(report);
         review.review.rating = Rating::Negative;
     }

--- a/crev-data/src/proof/review/package.rs
+++ b/crev-data/src/proof/review/package.rs
@@ -210,7 +210,7 @@ impl fmt::Display for PackageDraft {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "kebab-case")]
 pub enum VersionRange {
     Minor,

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -146,7 +146,7 @@ impl Local {
         let repo = Self::new()?;
         fs::create_dir_all(&repo.cache_remotes_path())?;
         if !repo.root_path.exists() || !repo.user_config_path().exists() {
-            bail!("User config not-initialized. Use `crev new id` to generate CrevID.");
+            bail!("User config not-initialized. Use `crev id new` to generate CrevID.");
         }
 
         *repo.user_config.borrow_mut() = Some(repo.load_user_config()?);
@@ -883,6 +883,15 @@ impl Local {
     pub fn list_own_ids(&self) -> Result<()> {
         for id in self.list_ids()? {
             println!("{} {}", id.id, id.url.url);
+        }
+        Ok(())
+    }
+
+    pub fn show_own_ids(&self) -> Result<()> {
+        let current = self.read_current_locked_id_opt()?.map(|id| id.to_pubid());
+        for id in self.list_ids()? {
+            let is_current = current.as_ref().map_or(false, |c| {c.id == id.id});
+            println!("{} {}{}", id.id, id.url.url, if is_current {" (current)"} else {""});
         }
         Ok(())
     }


### PR DESCRIPTION
```diff 
 SUBCOMMANDS:
-    advise      Create advisory urging to upgrade to given package version
     clean       Clean a crate source code (eg. after review)
     diff        Diff between two versions of a package
     distrust    Distrust an Id
     edit        Edit README.md of the current Id, ...
-    export      Export an id, ...
     fetch       Fetch proofs from external sources
-    flag        Flag a crate as buggy/low-quality/dangerous
     git         Run raw git commands in the local proof repository
     goto        Start a shell in source directory of a crate under review
     help        Prints this message or the help of the given subcommand(s)
-    new         Create an Id, ...
+    id          Manage your own Id (create new, show, export, import, switch)
     import      Import proofs, ...
     open        Open source code of a crate
     publish     Commit and Push local changes to the public proof repository (alias to `git commit -a && git push
                 HEAD`)
     pull        Pull changes from the public proof repository (alias to `git pull`)
     push        Push local changes to the public proof repository (alias to `git push HEAD`)
     query       Query Ids, packages, reviews...
-    report      Report that the crate is affected by a certain issue
-    switch      Switch current Id, ...
     review      Review a crate (code review, security advisory, flag issues)
     trust       Trust an Id
     update      Update data from online sources (crates.io)
     verify      Verify dependencies
```

And managing ID is all in one place:

```
SUBCOMMANDS:
    export    Export your own Id
    help      Prints this message or the help of the given subcommand(s)
    import    Import an Id as your own
    new       Create a new Id
    show      Show your own Id
    switch    Change current Id
```

`show` combines `query id current` and `query id own` into one by adding "(current)" annotation. `query` remained unchanged.

